### PR TITLE
Fix discrepancies between GoCD and plugin messages

### DIFF
--- a/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/FileBasedSecretsPlugin.java
+++ b/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/FileBasedSecretsPlugin.java
@@ -37,7 +37,6 @@ public class FileBasedSecretsPlugin extends AbstractGoPlugin {
     public static final Gson GSON = new GsonBuilder().serializeNulls().create();
     public static Logger LOGGER = Logger.getLoggerFor(FileBasedSecretsPlugin.class);
 
-
     @Override
     public GoPluginApiResponse handle(GoPluginApiRequest request) throws UnhandledRequestTypeException {
         Optional<RequestFromServer> requestFromServer = RequestFromServer.fromString(request.requestName());

--- a/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/FileBasedSecretsPlugin.java
+++ b/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/FileBasedSecretsPlugin.java
@@ -19,6 +19,7 @@ package cd.go.plugin.secret.filebased;
 import cd.go.plugin.secret.filebased.executors.*;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.thoughtworks.go.plugin.api.AbstractGoPlugin;
 import com.thoughtworks.go.plugin.api.GoApplicationAccessor;
 import com.thoughtworks.go.plugin.api.GoPlugin;
 import com.thoughtworks.go.plugin.api.GoPluginIdentifier;
@@ -32,13 +33,10 @@ import java.util.Arrays;
 import java.util.Optional;
 
 @Extension
-public class FileBasedSecretsPlugin implements GoPlugin {
+public class FileBasedSecretsPlugin extends AbstractGoPlugin {
     public static final Gson GSON = new GsonBuilder().serializeNulls().create();
     public static Logger LOGGER = Logger.getLoggerFor(FileBasedSecretsPlugin.class);
 
-    @Override
-    public void initializeGoApplicationAccessor(GoApplicationAccessor goApplicationAccessor) {
-    }
 
     @Override
     public GoPluginApiResponse handle(GoPluginApiRequest request) throws UnhandledRequestTypeException {
@@ -58,6 +56,10 @@ public class FileBasedSecretsPlugin implements GoPlugin {
                     return new VerifyConnectionRequestExecutor().execute(request);
                 case REQUEST_GET_PLUGIN_ICON:
                     return new GetIconRequestExecutor().execute();
+                case PLUGIN_SETTINGS_GET_CONFIGURATION:
+                case PLUGIN_SETTINGS_GET_VIEW:
+                case PLUGIN_SETTINGS_VALIDATE_CONFIGURATION:
+                    return null;
             }
         }
 

--- a/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/executors/GetConfigRequestExecutor.java
+++ b/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/executors/GetConfigRequestExecutor.java
@@ -19,6 +19,8 @@ package cd.go.plugin.secret.filebased.executors;
 import cd.go.plugin.secret.filebased.FileBasedSecretsPlugin;
 import cd.go.plugin.secret.filebased.model.Field;
 import cd.go.plugin.secret.filebased.model.FilePathField;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 
@@ -32,17 +34,17 @@ import static cd.go.plugin.secret.filebased.model.SecretsConfiguration.SECRETS_F
 
 
 public class GetConfigRequestExecutor {
+    public static final Gson GSON = new GsonBuilder().serializeNulls().create();
 
     public static final List<Field> FIELD_LIST = Arrays.asList(
-            new FilePathField(SECRETS_FILE_PATH_PROPERTY,
-                    "Secrets file path",
-                    "0",
+            new FilePathField(SECRETS_FILE_PATH_PROPERTY, "Secrets file path",
+                    true,
                     true)
     );
 
     public static final Map<String, Field> FIELDS = FIELD_LIST.stream().collect(Collectors.toMap(Field::getKey, Function.identity()));
 
     public GoPluginApiResponse execute() {
-        return DefaultGoPluginApiResponse.success(FileBasedSecretsPlugin.GSON.toJson(FIELDS));
+        return DefaultGoPluginApiResponse.success(GSON.toJson(FIELD_LIST));
     }
 }

--- a/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/executors/LookupSecretsRequestExecutor.java
+++ b/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/executors/LookupSecretsRequestExecutor.java
@@ -27,12 +27,17 @@ import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import java.io.File;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static cd.go.plugin.secret.filebased.FileBasedSecretsPlugin.*;
 
 public class LookupSecretsRequestExecutor {
     public GoPluginApiResponse execute(GoPluginApiRequest request) {
         LookupSecretRequest lookupSecretsRequest = LookupSecretRequest.fromJSON(request.requestBody());
-        HashMap<String, String> response = new HashMap<>();
+        List<Map<String, String>> responseList = new ArrayList<>();
 
         File secretsFile = new File(lookupSecretsRequest.getSecretsFilePath());
 
@@ -41,13 +46,16 @@ public class LookupSecretsRequestExecutor {
             for (String key : lookupSecretsRequest.getKeys()) {
                 String secret = secretsDatabase.getSecret(key);
                 if (secret != null) {
-                    response.put(key, secret);
+                    Map<String, String> response = new HashMap<>();
+                    response.put("key", key);
+                    response.put("value", secret);
+                    responseList.add(response);
                 }
             }
 
         } catch (IOException | GeneralSecurityException | BadSecretException e) {
             return DefaultGoPluginApiResponse.error("Error while looking up secrets: " + e.getMessage());
         }
-        return DefaultGoPluginApiResponse.success(FileBasedSecretsPlugin.GSON.toJson(response));
+        return DefaultGoPluginApiResponse.success(GSON.toJson(responseList));
     }
 }

--- a/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/executors/RequestFromServer.java
+++ b/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/executors/RequestFromServer.java
@@ -24,7 +24,10 @@ public enum RequestFromServer {
     REQUEST_GET_CONFIG_METADATA(String.join(".", Constants.REQUEST_PREFIX, Constants._SECRETS_CONFIG_METADATA, "get-metadata")),
     REQUEST_GET_CONFIG_VIEW(String.join(".", Constants.REQUEST_PREFIX, Constants._SECRETS_CONFIG_METADATA, "get-view")),
     REQUEST_VALIDATE_CONFIG(String.join(".", Constants.REQUEST_PREFIX, Constants._SECRETS_CONFIG_METADATA, "validate")),
-    REQUEST_VERIFY_CONNECTION(String.join(".", Constants.REQUEST_PREFIX, Constants._SECRETS_CONFIG_METADATA, "verify-connection"));
+    REQUEST_VERIFY_CONNECTION(String.join(".", Constants.REQUEST_PREFIX, Constants._SECRETS_CONFIG_METADATA, "verify-connection")),
+    PLUGIN_SETTINGS_GET_CONFIGURATION(Constants.GO_PLUGIN_SETTINGS_PREFIX + ".get-configuration"),
+    PLUGIN_SETTINGS_GET_VIEW(Constants.GO_PLUGIN_SETTINGS_PREFIX + ".get-view"),
+    PLUGIN_SETTINGS_VALIDATE_CONFIGURATION(Constants.GO_PLUGIN_SETTINGS_PREFIX + ".validate-configuration");
 
 
     private final String requestName;
@@ -51,5 +54,6 @@ public enum RequestFromServer {
     private interface Constants {
         String REQUEST_PREFIX = "go.cd.secrets";
         String _SECRETS_CONFIG_METADATA = "secrets-config";
+        String GO_PLUGIN_SETTINGS_PREFIX = "go.plugin-settings";
     }
 }

--- a/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/model/Field.java
+++ b/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/model/Field.java
@@ -7,26 +7,17 @@ import com.google.gson.annotations.SerializedName;
 import java.util.Optional;
 
 public abstract class Field {
-    private String key;
+    @Expose
+    @SerializedName("key")
+    protected String key;
 
     @Expose
-    @SerializedName("display-name")
-    protected String displayName;
+    @SerializedName("metadata")
+    protected Metadata metadata;
 
-    @Expose
-    @SerializedName("display-order")
-    protected String displayOrder;
-
-    @Expose
-    @SerializedName("required")
-    protected Boolean required;
-
-    public Field(String key, String displayName, String displayOrder, Boolean required) {
+    public Field(String key, String displayName, boolean required, boolean secure) {
         this.key = key;
-
-        this.displayName = displayName;
-        this.displayOrder = displayOrder;
-        this.required = required;
+        this.metadata = new Metadata(required, secure, displayName);
     }
 
 

--- a/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/model/FilePathField.java
+++ b/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/model/FilePathField.java
@@ -4,8 +4,8 @@ import java.io.File;
 import java.util.Optional;
 
 public class FilePathField extends NonBlankField {
-    public FilePathField(String key, String displayName, String displayOrder, Boolean required) {
-        super(key, displayName, displayOrder, required);
+    public FilePathField(String key, String displayName, boolean required, boolean secure) {
+        super(key, displayName, required, secure);
     }
 
     @Override
@@ -18,7 +18,7 @@ public class FilePathField extends NonBlankField {
 
         if (!new File(filePath).exists()) {
             return Optional.of(
-                    String.format("'%s' must contain a valid file path", displayName)
+                    String.format("'%s' must contain a valid file path", metadata.getDisplayName())
             );
         }
         return Optional.empty();

--- a/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/model/LookupSecretRequest.java
+++ b/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/model/LookupSecretRequest.java
@@ -34,6 +34,8 @@ public class LookupSecretRequest {
     @SerializedName("keys")
     private List<String> keys;
 
+    public LookupSecretRequest() {}
+
     public LookupSecretRequest(String secretsFilePath, List<String> keys) {
         this.configuration = new SecretsConfiguration(secretsFilePath);
         this.keys = keys;

--- a/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/model/LookupSecretRequest.java
+++ b/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/model/LookupSecretRequest.java
@@ -31,7 +31,7 @@ public class LookupSecretRequest {
     private SecretsConfiguration configuration;
 
     @Expose
-    @SerializedName("Keys")
+    @SerializedName("keys")
     private List<String> keys;
 
     public LookupSecretRequest(String secretsFilePath, List<String> keys) {

--- a/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/model/Metadata.java
+++ b/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/model/Metadata.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.plugin.secret.filebased.model;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+class Metadata {
+    @Expose
+    @SerializedName("required")
+    private final boolean required;
+
+    @Expose
+    @SerializedName("secure")
+    private final boolean secure;
+
+    @Expose
+    @SerializedName("display_name")
+    private final String displayName;
+
+    public Metadata(boolean required, boolean secure, String displayName) {
+        this.required = required;
+        this.secure = secure;
+        this.displayName = displayName;
+    }
+
+    public boolean isRequired() {
+        return required;
+    }
+
+    public boolean isSecure() {
+        return secure;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Metadata metadata = (Metadata) o;
+
+        if (required != metadata.required) return false;
+        if (secure != metadata.secure) return false;
+        return displayName != null ? displayName.equals(metadata.displayName) : metadata.displayName == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (required ? 1 : 0);
+        result = 31 * result + (secure ? 1 : 0);
+        result = 31 * result + (displayName != null ? displayName.hashCode() : 0);
+        return result;
+    }
+}

--- a/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/model/NonBlankField.java
+++ b/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/model/NonBlankField.java
@@ -5,15 +5,15 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.Optional;
 
 public class NonBlankField extends Field {
-    public NonBlankField(String key, String displayName, String displayOrder, Boolean required) {
-        super(key, displayName, displayOrder, required);
+    public NonBlankField(String key, String displayName, boolean required, boolean secure) {
+        super(key, displayName, required, secure);
     }
 
     @Override
     public Optional<String> validate(String input) {
         if (StringUtils.isBlank(input)) {
             return Optional.of(
-                    String.format("%s must not be blank", displayName)
+                    String.format("%s must not be blank", metadata.getDisplayName())
             );
         }
         return Optional.empty();

--- a/gocd-file-based-secrets-plugin/src/test/java/cd/go/plugin/secret/filebased/FileBasedSecretsPluginTest.java
+++ b/gocd-file-based-secrets-plugin/src/test/java/cd/go/plugin/secret/filebased/FileBasedSecretsPluginTest.java
@@ -56,7 +56,7 @@ class FileBasedSecretsPluginTest {
             request.setRequestBody(lookupSecretRequest.toJSON());
             GoPluginApiResponse response = new FileBasedSecretsPlugin().handle(request);
 
-            JSONAssert.assertEquals(response.responseBody(), "{\"secret-key\":\"secret-value\"}", false);
+            JSONAssert.assertEquals("[{\"key\":\"secret-key\", \"value\":\"secret-value\"}]", response.responseBody(), false);
         }
 
         @Test
@@ -68,7 +68,7 @@ class FileBasedSecretsPluginTest {
             request.setRequestBody(lookupSecretRequest.toJSON());
             GoPluginApiResponse response = new FileBasedSecretsPlugin().handle(request);
 
-            JSONAssert.assertEquals(response.responseBody(), "{}", false);
+            JSONAssert.assertEquals(response.responseBody(), "[]", false);
         }
     }
 }

--- a/gocd-file-based-secrets-plugin/src/test/java/cd/go/plugin/secret/filebased/executors/GetConfigRequestExecutorTest.java
+++ b/gocd-file-based-secrets-plugin/src/test/java/cd/go/plugin/secret/filebased/executors/GetConfigRequestExecutorTest.java
@@ -30,6 +30,15 @@ class GetConfigRequestExecutorTest {
 
         assertThat(response.responseCode()).isEqualTo(200);
 
-        JSONAssert.assertEquals("{\"SecretsFilePath\":{\"display-order\":\"0\",\"display-name\":\"Secrets file path\",\"required\":true}}", response.responseBody(), false);
+        JSONAssert.assertEquals("[\n" +
+                "  {\n" +
+                "    \"key\": \"SecretsFilePath\",\n" +
+                "    \"metadata\": {\n" +
+                "      \"secure\": true,\n" +
+                "      \"display_name\": \"Secrets file path\",\n" +
+                "      \"required\": true\n" +
+                "    }\n" +
+                "  }\n" +
+                "]", response.responseBody(), false);
     }
 }

--- a/gocd-file-based-secrets-plugin/src/test/java/cd/go/plugin/secret/filebased/executors/LookupSecretsRequestExecutorTest.java
+++ b/gocd-file-based-secrets-plugin/src/test/java/cd/go/plugin/secret/filebased/executors/LookupSecretsRequestExecutorTest.java
@@ -20,9 +20,11 @@ import cd.go.plugin.secret.filebased.db.SecretsDatabase;
 import cd.go.plugin.secret.filebased.model.LookupSecretRequest;
 import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
+import org.json.JSONException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,6 +36,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 class LookupSecretsRequestExecutorTest {
     private File databaseFile;
@@ -45,14 +48,19 @@ class LookupSecretsRequestExecutorTest {
     }
 
     @Test
-    void shouldLookupSecrets() {
+    void shouldLookupSecrets() throws JSONException {
         GoPluginApiRequest request = mock(GoPluginApiRequest.class);
         when(request.requestBody()).thenReturn(new LookupSecretRequest(databaseFile.getAbsolutePath(), Arrays.asList("secret-key", "param1")).toJSON());
 
         GoPluginApiResponse response = new LookupSecretsRequestExecutor().execute(request);
 
         assertThat(response.responseCode()).isEqualTo(200);
-        assertThat(response.responseBody()).isEqualTo("{\"secret-key\":\"secret-value\"}");
+        assertEquals("[\n" +
+                "  {\n" +
+                "    \"key\": \"secret-key\",\n" +
+                "    \"value\": \"secret-value\"\n" +
+                "  }\n" +
+                "]", response.responseBody(), false);
     }
 
     @Test
@@ -64,7 +72,7 @@ class LookupSecretsRequestExecutorTest {
         GoPluginApiResponse response = new LookupSecretsRequestExecutor().execute(request);
 
         assertThat(response.responseCode()).isEqualTo(200);
-        assertThat(response.responseBody()).isEqualTo("{}");
+        assertThat(response.responseBody()).isEqualTo("[]");
     }
 
 }

--- a/gocd-file-based-secrets-plugin/src/test/java/cd/go/plugin/secret/filebased/executors/ValidateConfigRequestExecutorTest.java
+++ b/gocd-file-based-secrets-plugin/src/test/java/cd/go/plugin/secret/filebased/executors/ValidateConfigRequestExecutorTest.java
@@ -18,9 +18,12 @@ package cd.go.plugin.secret.filebased.executors;
 
 import com.google.gson.Gson;
 import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
+import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
+import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,16 +35,24 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.skyscreamer.jsonassert.JSONAssert.*;
 
 class ValidateConfigRequestExecutorTest {
 
     @Test
-    void shouldReturnErrorSecretFilePathIsEmpty() {
+    void shouldReturnErrorSecretFilePathIsEmpty() throws JSONException {
         GoPluginApiRequest request = mock(GoPluginApiRequest.class);
         when(request.requestBody()).thenReturn(new Gson().toJson(Collections.singletonMap("SecretsFilePath", "")));
 
         GoPluginApiResponse response = new ValidateConfigRequestExecutor().execute(request);
-        assertThat(response.responseBody()).isEqualTo("{\"errors\":{\"SecretsFilePath\":\"Secrets file path must not be blank\"}}");
+
+        assertThat(response.responseCode()).isEqualTo(DefaultGoPluginApiResponse.VALIDATION_FAILED);
+        assertEquals("[\n" +
+                "  {\n" +
+                "    \"key\": \"SecretsFilePath\",\n" +
+                "    \"message\": \"Secrets file path must not be blank\"\n" +
+                "  }\n" +
+                "]", response.responseBody(), false);
     }
 
     @Test
@@ -56,6 +67,7 @@ class ValidateConfigRequestExecutorTest {
         when(request.requestBody()).thenReturn(new Gson().toJson(requestMap));
 
         GoPluginApiResponse response = new ValidateConfigRequestExecutor().execute(request);
-        assertThat(response.responseBody()).isEqualTo("{\"errors\":{}}");
+        assertThat(response.responseCode()).isEqualTo(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE);
+        assertThat(response.responseBody()).isEqualTo("[]");
     }
 }


### PR DESCRIPTION
Issue: https://github.com/gocd/gocd/issues/5838

Fixes:
 - Ignore settings related calls as plugin-settings is not supported by file-based-plugin
 - There were some discrepancies between what plugin returned as a response and what GoCD expected, changed plugin side to conform to GoCD response formats.
