### PR TITLE
Make name and value parameters required

### DIFF
--- a/cli/src/main/java/cd/go/plugin/secret/filebased/cli/args/AddSecretArgs.java
+++ b/cli/src/main/java/cd/go/plugin/secret/filebased/cli/args/AddSecretArgs.java
@@ -27,7 +27,7 @@ import java.util.function.Consumer;
 @Parameters(commandDescription = "Adds a secret", commandNames = "add")
 public class AddSecretArgs extends HasNameArgs {
 
-    @Parameter(names = {"--value", "-v"}, description = "The value of the secret.", password = true)
+    @Parameter(names = {"--value", "-v"}, required = true, description = "The value of the secret.", password = true)
     public String secret;
 
     public void execute(Consumer<Integer> exitter) throws IOException, GeneralSecurityException {

--- a/cli/src/main/java/cd/go/plugin/secret/filebased/cli/args/HasNameArgs.java
+++ b/cli/src/main/java/cd/go/plugin/secret/filebased/cli/args/HasNameArgs.java
@@ -19,6 +19,6 @@ package cd.go.plugin.secret.filebased.cli.args;
 import com.beust.jcommander.Parameter;
 
 public abstract class HasNameArgs extends DatabaseFileArgs {
-    @Parameter(names = {"--name", "-n"}, description = "The name of the secret to remove.")
+    @Parameter(names = {"--name", "-n"}, required = true, description = "The name of the secret to remove.")
     public String key;
 }


### PR DESCRIPTION
Fixes following bugs in command line utility:

 - Add option: Without the -v or -n flag the utility currently throws a null pointer exception. 

 - Show option: Without -n option the utility currently returns with message "Secret name null was not found".

 - Remove option: Without -n option the utility currently returns with message "Secret name null was not found". 

It deals with above scenarios by showing usage message.