### PR TITLE
Command line utility changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,32 @@ To build the jar, run `./gradlew clean test assemble`
   java -jar gocd-file-based-secrets-plugin-$VERSION$.jar remove -f secret.db -n my-password
   ```
 
+## Configuration
+
+The plugin needs to be configured to use the secrets database file. 
+
+The configuration can be added directly to the `config.xml` using the `<secretConfig>` configuration.
+
+* Example Configuration
+
+    ```xml
+    <secretConfig id="Env1Secrets" pluginId="cd.go.secrets.file-based-plugin">
+        <description>All secrets for env1</description>
+         <configuration>
+            <property>
+                <key>SecretsFilePath</key>
+                <value>/godata/config/secretsDatabase.json</value>
+            </property>
+        </configuration>
+        <rules>
+            <allow action="refer" type="environment">env_*</allow>
+            <deny action="refer" type="pipeline_group">my_group</deny>
+            <allow action="refer" type="pipeline_group">other_group</allow>  
+        </rules>
+    </secretConfig>
+    ```
+`<rules>` tag defines where this secretConfig is allowed/denied to be referred.
+
 ## Troubleshooting
 
 ### Verify Connection

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ To build the jar, run `./gradlew clean test assemble`
 ## Usage instructions
   
   1. Download the plugin jar from the [GitHub Releases page](https://github.com/gocd/gocd-file-based-secrets-plugin)
-  2. Execute the `init` command to initialize the secret database:
+  2. Execute the `init` command to initialize the secret database. Although it's optional but it is recommended to 
+  store your secret file under CONFIG_DIR. Doing this will make secrets database file part of the backup process. 
+  The CONFIG_DIR is typically /etc/go on Linux and C:\Program Files\Go Server\config on Windows. 
+
   ```shell
   java -jar gocd-file-based-secrets-plugin-$VERSION$.jar init -f secret.db
   ```
@@ -43,22 +46,59 @@ The configuration can be added directly to the `config.xml` using the `<secretCo
 * Example Configuration
 
     ```xml
-    <secretConfig id="Env1Secrets" pluginId="cd.go.secrets.file-based-plugin">
-        <description>All secrets for env1</description>
-         <configuration>
-            <property>
-                <key>SecretsFilePath</key>
-                <value>/godata/config/secretsDatabase.json</value>
-            </property>
-        </configuration>
-        <rules>
-            <allow action="refer" type="environment">env_*</allow>
-            <deny action="refer" type="pipeline_group">my_group</deny>
-            <allow action="refer" type="pipeline_group">other_group</allow>  
-        </rules>
-    </secretConfig>
+    <secretConfigs>
+      <secretConfig id="Env1Secrets" pluginId="cd.go.secrets.file-based-plugin">
+          <description>All secrets for env1</description>
+           <configuration>
+              <property>
+                  <key>SecretsFilePath</key>
+                  <value>/godata/config/secretsDatabase.json</value>
+              </property>
+          </configuration>
+          <rules>
+              <allow action="refer" type="environment">env_*</allow>
+              <deny action="refer" type="pipeline_group">my_group</deny>
+              <allow action="refer" type="pipeline_group">other_group</allow>
+          </rules>
+      </secretConfig>
+    </secretConfigs>
     ```
 `<rules>` tag defines where this secretConfig is allowed/denied to be referred.
+
+* The plugin can also be configured to use multiple secret database files if required:
+
+    ```xml
+    <secretConfigs>
+      <secretConfig id="Env1Secrets" pluginId="cd.go.secrets.file-based-plugin">
+          <description>All secrets for env1</description>
+           <configuration>
+              <property>
+                  <key>SecretsFilePath</key>
+                  <value>/godata/config/secretsDatabase.json</value>
+              </property>
+          </configuration>
+          <rules>
+              <allow action="refer" type="environment">env_*</allow>
+              <deny action="refer" type="pipeline_group">my_group</deny>
+              <allow action="refer" type="pipeline_group">other_group</allow>
+          </rules>
+      </secretConfig>
+      <secretConfig id="Env2Secrets" pluginId="cd.go.secrets.file-based-plugin">
+          <description>All secrets for env1</description>
+           <configuration>
+              <property>
+                  <key>SecretsFilePath</key>
+                  <value>/godata/config/secretsDatabase_env2.json</value>
+              </property>
+          </configuration>
+          <rules>
+              <allow action="refer" type="environment">env_*</allow>
+              <deny action="refer" type="pipeline_group">my_group</deny>
+              <allow action="refer" type="pipeline_group">other_group</allow>
+          </rules>
+      </secretConfig>
+    </secretConfigs>
+    ```
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ To build the jar, run `./gradlew clean test assemble`
   ```shell
   java -jar gocd-file-based-secrets-plugin-$VERSION$.jar show -f secret.db -n my-password
   ```
-  5. Remove a secret:
+  5. Show all secret keys:
+  ```shell
+  java -jar gocd-file-based-secrets-plugin-$VERSION$.jar keys -f secret.db
+  ```
+  6. Remove a secret:
   ```shell
   java -jar gocd-file-based-secrets-plugin-$VERSION$.jar remove -f secret.db -n my-password
   ```

--- a/cli/src/main/java/cd/go/plugin/secret/filebased/cli/Main.java
+++ b/cli/src/main/java/cd/go/plugin/secret/filebased/cli/Main.java
@@ -40,6 +40,7 @@ public class Main {
         AddSecretArgs addSecretArgs = new AddSecretArgs();
         RemoveSecretArgs removeSecretArgs = new RemoveSecretArgs();
         ShowSecretArgs showSecretArgs = new ShowSecretArgs();
+        ShowAllSecretKeysArgs keysArgs = new ShowAllSecretKeysArgs();
 
         JCommander cmd = JCommander.newBuilder()
                 .addObject(rootArgs)
@@ -47,6 +48,7 @@ public class Main {
                 .addCommand(addSecretArgs)
                 .addCommand(removeSecretArgs)
                 .addCommand(showSecretArgs)
+                .addCommand(keysArgs)
                 .build();
 
         String parsedCommand = null;
@@ -71,6 +73,9 @@ public class Main {
                     break;
                 case "show":
                     showSecretArgs.execute(exitter);
+                    break;
+                case "keys":
+                    keysArgs.execute(exitter);
                     break;
                 default:
                     throw new UnsupportedOperationException(parsedCommand);

--- a/cli/src/main/java/cd/go/plugin/secret/filebased/cli/Main.java
+++ b/cli/src/main/java/cd/go/plugin/secret/filebased/cli/Main.java
@@ -91,6 +91,8 @@ public class Main {
 
     private static void printUsageAndExit(JCommander cmd, String parsedCommand, int statusCode, Consumer<Integer> exitter) {
         StringBuilder out = new StringBuilder();
+        cmd.setProgramName("java -jar <path.to.plugin.jar.file>");
+        cmd.setColumnSize(100);
         if (parsedCommand == null) {
             cmd.usage(out);
         } else {

--- a/cli/src/main/java/cd/go/plugin/secret/filebased/cli/args/AddSecretArgs.java
+++ b/cli/src/main/java/cd/go/plugin/secret/filebased/cli/args/AddSecretArgs.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.function.Consumer;
 
-@Parameters(commandDescription = "Adds a secret", commandNames = "add")
+@Parameters(commandDescription = "Adds a secret.", commandNames = "add")
 public class AddSecretArgs extends HasNameArgs {
 
     @Parameter(names = {"--value", "-v"}, required = true, description = "The value of the secret.", password = true)

--- a/cli/src/main/java/cd/go/plugin/secret/filebased/cli/args/InitArgs.java
+++ b/cli/src/main/java/cd/go/plugin/secret/filebased/cli/args/InitArgs.java
@@ -25,7 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.util.function.Consumer;
 
-@Parameters(commandDescription = "Initialize the secret database file", commandNames = "init")
+@Parameters(commandDescription = "Initialize the secret database file. Should be run before any other commands as it generates secrets database file used by other commands.", commandNames = "init")
 public class InitArgs extends DatabaseFileArgs {
     public void execute(Consumer<Integer> exitter) throws NoSuchAlgorithmException, IOException {
         FileUtils.write(databaseFile, new SecretsDatabase().toJSON(), StandardCharsets.UTF_8);

--- a/cli/src/main/java/cd/go/plugin/secret/filebased/cli/args/RemoveSecretArgs.java
+++ b/cli/src/main/java/cd/go/plugin/secret/filebased/cli/args/RemoveSecretArgs.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.function.Consumer;
 
-@Parameters(commandDescription = "Removes given secret", commandNames = "remove")
+@Parameters(commandDescription = "Removes given secret.", commandNames = "remove")
 public class RemoveSecretArgs extends HasNameArgs {
     public void execute(Consumer<Integer> exitter) throws IOException, BadSecretException, GeneralSecurityException {
         SecretsDatabase secretsDatabase = SecretsDatabase.readFrom(databaseFile);

--- a/cli/src/main/java/cd/go/plugin/secret/filebased/cli/args/ShowAllSecretKeysArgs.java
+++ b/cli/src/main/java/cd/go/plugin/secret/filebased/cli/args/ShowAllSecretKeysArgs.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.plugin.secret.filebased.cli.args;
+
+import cd.go.plugin.secret.filebased.db.BadSecretException;
+import cd.go.plugin.secret.filebased.db.SecretsDatabase;
+import com.beust.jcommander.Parameters;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Consumer;
+
+@Parameters(commandDescription = "Returns all secret keys", commandNames = "keys")
+public class ShowAllSecretKeysArgs extends DatabaseFileArgs {
+    public void execute(Consumer<Integer> exitter) throws IOException, BadSecretException, GeneralSecurityException {
+        Set<String> secretKeys = SecretsDatabase.readFrom(databaseFile).getAllSecretKeys();
+
+        if (!secretKeys.isEmpty()) {
+            System.out.println(secretKeys);
+        } else {
+            System.err.println("There are no secrets in the secrets database file.");
+            exitter.accept(-1);
+        }
+    }
+}

--- a/cli/src/main/java/cd/go/plugin/secret/filebased/cli/args/ShowAllSecretKeysArgs.java
+++ b/cli/src/main/java/cd/go/plugin/secret/filebased/cli/args/ShowAllSecretKeysArgs.java
@@ -26,7 +26,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 
-@Parameters(commandDescription = "Returns all secret keys", commandNames = "keys")
+@Parameters(commandDescription = "Returns all secret keys.", commandNames = "keys")
 public class ShowAllSecretKeysArgs extends DatabaseFileArgs {
     public void execute(Consumer<Integer> exitter) throws IOException, BadSecretException, GeneralSecurityException {
         Set<String> secretKeys = SecretsDatabase.readFrom(databaseFile).getAllSecretKeys();

--- a/cli/src/main/java/cd/go/plugin/secret/filebased/cli/args/ShowSecretArgs.java
+++ b/cli/src/main/java/cd/go/plugin/secret/filebased/cli/args/ShowSecretArgs.java
@@ -26,7 +26,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 
-@Parameters(commandDescription = "Returns value for given secret", commandNames = "show")
+@Parameters(commandDescription = "Returns value for given secret.", commandNames = "show")
 public class ShowSecretArgs extends HasNameArgs {
     public void execute(Consumer<Integer> exitter) throws IOException, BadSecretException, GeneralSecurityException {
         String secret = SecretsDatabase.readFrom(databaseFile).getSecret(key);

--- a/cli/src/main/java/cd/go/plugin/secret/filebased/cli/args/ShowSecretArgs.java
+++ b/cli/src/main/java/cd/go/plugin/secret/filebased/cli/args/ShowSecretArgs.java
@@ -22,6 +22,8 @@ import com.beust.jcommander.Parameters;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Consumer;
 
 @Parameters(commandDescription = "Returns value for given secret", commandNames = "show")
@@ -30,7 +32,7 @@ public class ShowSecretArgs extends HasNameArgs {
         String secret = SecretsDatabase.readFrom(databaseFile).getSecret(key);
 
         if (secret != null) {
-            System.out.print(secret);
+            System.out.println(secret);
         } else {
             System.err.println("Secret named " + key + " was not found.");
             exitter.accept(-1);

--- a/cli/src/test/java/cd/go/plugin/secret/filebased/cli/MainTest.java
+++ b/cli/src/test/java/cd/go/plugin/secret/filebased/cli/MainTest.java
@@ -43,7 +43,7 @@ class MainTest {
         void shouldPrintUsageAndExitWithBadStatusWhenNoOptionIsProvided() throws Exception {
             Util.withCapturedSysOut((out, err) -> {
                 new Main().run(dummyExitter);
-                assertThat(err.toString()).startsWith("Usage: <main class> [options] [command] [command options]");
+                assertThat(err.toString()).startsWith("Usage: java -jar <path.to.plugin.jar.file> [options] [command] [command options]");
                 assertThat(out.toString()).isEmpty();
                 verify(dummyExitter).accept(1);
             });
@@ -53,7 +53,7 @@ class MainTest {
         void shouldPrintUsageAndExitWithBadStatusWhenHelpOptionIsProvided() throws Exception {
             Util.withCapturedSysOut((out, err) -> {
                 new Main("-h").run(dummyExitter);
-                assertThat(err.toString()).startsWith("Usage: <main class> [options] [command] [command options]");
+                assertThat(err.toString()).startsWith("Usage: java -jar <path.to.plugin.jar.file> [options] [command] [command options]");
                 assertThat(out.toString()).isEmpty();
                 verify(dummyExitter).accept(1);
             });

--- a/cli/src/test/java/cd/go/plugin/secret/filebased/cli/MainTest.java
+++ b/cli/src/test/java/cd/go/plugin/secret/filebased/cli/MainTest.java
@@ -141,7 +141,7 @@ class MainTest {
 
             Util.withCapturedSysOut((out, err) -> {
                 new Main("show", "-f", databaseFile.getAbsolutePath(), "-n", "username").run(dummyExitter);
-                assertThat(out.toString()).isEqualTo("foo");
+                assertThat(out.toString()).isEqualToIgnoringNewLines("foo");
                 assertThat(err.toString()).isEmpty();
                 verifyNoMoreInteractions(dummyExitter);
             });
@@ -171,6 +171,39 @@ class MainTest {
                 assertThat(err.toString())
                         .contains("FileNotFoundException")
                         .contains(databaseFile.getAbsolutePath());
+                verify(dummyExitter).accept(-1);
+            });
+        }
+    }
+
+
+    @Nested
+    class LookupAllKeys {
+        @Test
+        void shouldLookupSecretKeys(@TempDir Path tempDirectory) throws Exception {
+            File databaseFile = new File(tempDirectory.toFile(), UUID.randomUUID().toString().substring(0, 8));
+            new SecretsDatabase()
+                    .addSecret("username", "foo")
+                    .addSecret("password", "bar")
+                    .saveTo(databaseFile);
+
+            Util.withCapturedSysOut((out, err) -> {
+                new Main("keys", "-f", databaseFile.getAbsolutePath()).run(dummyExitter);
+                assertThat(out.toString()).isEqualToIgnoringNewLines("[username, password]");
+                verifyNoMoreInteractions(dummyExitter);
+            });
+        }
+
+        @Test
+        void shouldPrintNoKeysMessageWhenSecretsAreNotPresent(@TempDir Path tempDirectory) throws Exception {
+            File databaseFile = new File(tempDirectory.toFile(), UUID.randomUUID().toString().substring(0, 8));
+            new SecretsDatabase()
+                    .saveTo(databaseFile);
+
+            Util.withCapturedSysOut((out, err) -> {
+                new Main("keys", "-f", databaseFile.getAbsolutePath()).run(dummyExitter);
+                assertThat(out.toString()).isEmpty();
+                assertThat(err.toString()).isEqualToIgnoringNewLines("There are no secrets in the secrets database file.");
                 verify(dummyExitter).accept(-1);
             });
         }

--- a/db/src/main/java/cd/go/plugin/secret/filebased/db/SecretsDatabase.java
+++ b/db/src/main/java/cd/go/plugin/secret/filebased/db/SecretsDatabase.java
@@ -29,6 +29,7 @@ import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.LinkedHashMap;
+import java.util.Set;
 
 import static org.apache.commons.io.FileUtils.readFileToString;
 
@@ -64,6 +65,10 @@ public class SecretsDatabase {
             return Cipher.decrypt(secretKey, secrets.get(name));
         }
         return null;
+    }
+
+    public Set<String> getAllSecretKeys() {
+        return secrets.keySet();
     }
 
     public SecretsDatabase removeSecret(String name) {

--- a/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/executors/LookupSecretsRequestExecutor.java
+++ b/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/executors/LookupSecretsRequestExecutor.java
@@ -20,6 +20,7 @@ import cd.go.plugin.secret.filebased.FileBasedSecretsPlugin;
 import cd.go.plugin.secret.filebased.db.BadSecretException;
 import cd.go.plugin.secret.filebased.db.SecretsDatabase;
 import cd.go.plugin.secret.filebased.model.LookupSecretRequest;
+import com.google.gson.Gson;
 import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
@@ -27,19 +28,19 @@ import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import java.io.File;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static cd.go.plugin.secret.filebased.FileBasedSecretsPlugin.*;
 
 public class LookupSecretsRequestExecutor {
+    public static final int NOT_FOUND_ERROR_CODE = 404;
+
     public GoPluginApiResponse execute(GoPluginApiRequest request) {
         LookupSecretRequest lookupSecretsRequest = LookupSecretRequest.fromJSON(request.requestBody());
         List<Map<String, String>> responseList = new ArrayList<>();
 
         File secretsFile = new File(lookupSecretsRequest.getSecretsFilePath());
+        List<String> unresolvedKeys = new ArrayList<>();
 
         try {
             SecretsDatabase secretsDatabase = SecretsDatabase.readFrom(secretsFile);
@@ -50,12 +51,19 @@ public class LookupSecretsRequestExecutor {
                     response.put("key", key);
                     response.put("value", secret);
                     responseList.add(response);
+                } else {
+                    unresolvedKeys.add(key);
                 }
             }
 
+            if (unresolvedKeys.isEmpty()) {
+                return DefaultGoPluginApiResponse.success(GSON.toJson(responseList));
+            }
+
+            Map<String, String> response = Collections.singletonMap("message", String.format("Secrets with keys %s not found.", unresolvedKeys));
+            return new DefaultGoPluginApiResponse(NOT_FOUND_ERROR_CODE, GSON.toJson(response));
         } catch (IOException | GeneralSecurityException | BadSecretException e) {
             return DefaultGoPluginApiResponse.error("Error while looking up secrets: " + e.getMessage());
         }
-        return DefaultGoPluginApiResponse.success(GSON.toJson(responseList));
     }
 }

--- a/gocd-file-based-secrets-plugin/src/test/java/cd/go/plugin/secret/filebased/executors/GetConfigRequestExecutorTest.java
+++ b/gocd-file-based-secrets-plugin/src/test/java/cd/go/plugin/secret/filebased/executors/GetConfigRequestExecutorTest.java
@@ -39,6 +39,6 @@ class GetConfigRequestExecutorTest {
                 "      \"required\": true\n" +
                 "    }\n" +
                 "  }\n" +
-                "]", response.responseBody(), false);
+                "]", response.responseBody(), true);
     }
 }

--- a/gocd-file-based-secrets-plugin/src/test/java/cd/go/plugin/secret/filebased/executors/ValidateConfigRequestExecutorTest.java
+++ b/gocd-file-based-secrets-plugin/src/test/java/cd/go/plugin/secret/filebased/executors/ValidateConfigRequestExecutorTest.java
@@ -52,7 +52,7 @@ class ValidateConfigRequestExecutorTest {
                 "    \"key\": \"SecretsFilePath\",\n" +
                 "    \"message\": \"Secrets file path must not be blank\"\n" +
                 "  }\n" +
-                "]", response.responseBody(), false);
+                "]", response.responseBody(), true);
     }
 
     @Test


### PR DESCRIPTION
Implements [5838](https://github.com/gocd/gocd/issues/5838)

Changes done are,
- Added support to list all the secret keys from a secrets database file
- Modified show command to print the secret value on a new line
- Improved documentation of the file-based plugin
- Sending proper error message when secret keys are not found in lookup secret call
- Improved usage description of command line utility
- Added suggestion to create the secrets database file in CONFIG_DIR so that it is included in back up process.