### PR TITLE
Upgrade to plugin-base:0.0.3

### DIFF
--- a/gocd-file-based-secrets-plugin/build.gradle
+++ b/gocd-file-based-secrets-plugin/build.gradle
@@ -19,7 +19,7 @@ configurations {
 }
 
 dependencies {
-    compile group: 'com.github.bdpiparva.plugin.base', name: 'gocd-plugin-base', version: '0.0.1'
+    compile group: 'com.github.bdpiparva.plugin.base', name: 'gocd-plugin-base', version: '0.0.3'
     compileOnly group: 'cd.go.plugin', name: 'go-plugin-api', version: '18.9.0'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
     compile project(':db')

--- a/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/FileBasedSecretsPlugin.java
+++ b/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/FileBasedSecretsPlugin.java
@@ -18,16 +18,13 @@ package cd.go.plugin.secret.filebased;
 
 import cd.go.plugin.secret.filebased.executors.LookupSecretsRequestExecutor;
 import cd.go.plugin.secret.filebased.model.SecretsConfiguration;
+import com.github.bdpiparva.plugin.base.dispatcher.BaseBuilder;
 import com.github.bdpiparva.plugin.base.dispatcher.RequestDispatcher;
-import com.github.bdpiparva.plugin.base.dispatcher.RequestDispatcherBuilder;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.thoughtworks.go.plugin.api.GoApplicationAccessor;
 import com.thoughtworks.go.plugin.api.GoPlugin;
 import com.thoughtworks.go.plugin.api.GoPluginIdentifier;
 import com.thoughtworks.go.plugin.api.annotation.Extension;
 import com.thoughtworks.go.plugin.api.exceptions.UnhandledRequestTypeException;
-import com.thoughtworks.go.plugin.api.logging.Logger;
 import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 
@@ -35,12 +32,14 @@ import java.util.Arrays;
 
 @Extension
 public class FileBasedSecretsPlugin implements GoPlugin {
+
     private RequestDispatcher requestDispatcher;
 
     @Override
     public void initializeGoApplicationAccessor(GoApplicationAccessor goApplicationAccessor) {
-        requestDispatcher = RequestDispatcherBuilder
-                .forSecret(goApplicationAccessor)
+        requestDispatcher = BaseBuilder
+                .forSecrets()
+                .v1()
                 .icon("/plugin-icon.svg", "image/svg+xml")
                 .configMetadata(SecretsConfiguration.class)
                 .configView("/secrets.template.html")

--- a/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/executors/LookupSecretsRequestExecutor.java
+++ b/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/executors/LookupSecretsRequestExecutor.java
@@ -19,7 +19,7 @@ package cd.go.plugin.secret.filebased.executors;
 import cd.go.plugin.secret.filebased.db.BadSecretException;
 import cd.go.plugin.secret.filebased.db.SecretsDatabase;
 import cd.go.plugin.secret.filebased.model.LookupSecretRequest;
-import com.github.bdpiparva.plugin.base.dispatcher.LookupExecutor;
+import com.github.bdpiparva.plugin.base.executors.secrets.LookupExecutor;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 


### PR DESCRIPTION
Utilizing `gocd-plugin-base:0.0.3`
An earlier version of the same had a bug in `get-template-view`