### PR TITLE
Added validation for secret file path.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ apply from: "https://raw.githubusercontent.com/gocd/gocd-plugin-gradle-task-help
 
 gocdPlugin {
   id = 'cd.go.secrets.file-based-plugin'
-  pluginVersion = '0.0.1'
+  pluginVersion = '0.0.2'
   goCdVersion = '19.3.0'
   name = 'File based secrets plugin for GoCD'
   description = 'File based secrets plugin for GoCD'

--- a/gocd-file-based-secrets-plugin/build.gradle
+++ b/gocd-file-based-secrets-plugin/build.gradle
@@ -19,7 +19,7 @@ configurations {
 }
 
 dependencies {
-    compile group: 'com.github.bdpiparva.plugin.base', name: 'gocd-plugin-base', version: '0.0.3'
+    compile group: 'com.github.bdpiparva.plugin.base', name: 'gocd-plugin-base', version: '0.0.5'
     compileOnly group: 'cd.go.plugin', name: 'go-plugin-api', version: '18.9.0'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
     compile project(':db')

--- a/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/FileBasedSecretsPlugin.java
+++ b/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/FileBasedSecretsPlugin.java
@@ -41,9 +41,9 @@ public class FileBasedSecretsPlugin implements GoPlugin {
                 .forSecrets()
                 .v1()
                 .icon("/plugin-icon.svg", "image/svg+xml")
-                .configMetadata(SecretsConfiguration.class)
+                .configMetadata(SecretsConfiguration.class, false)
                 .configView("/secrets.template.html")
-                .validateSecretConfig()
+                .validateSecretConfig(new SecretFilePathValidator())
                 .lookup(new LookupSecretsRequestExecutor())
                 .build();
     }

--- a/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/SecretFilePathValidator.java
+++ b/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/SecretFilePathValidator.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.plugin.secret.filebased;
+
+import com.github.bdpiparva.plugin.base.validation.ValidationResult;
+import com.github.bdpiparva.plugin.base.validation.Validator;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+import java.util.Map;
+
+import static cd.go.plugin.secret.filebased.model.SecretsConfiguration.SECRETS_FILE_PATH_PROPERTY;
+
+public class SecretFilePathValidator implements Validator {
+
+    @Override
+    public ValidationResult validate(Map<String, String> requestBody) {
+        ValidationResult validationResult = new ValidationResult();
+        String filePath = requestBody.get(SECRETS_FILE_PATH_PROPERTY);
+        if (StringUtils.isBlank(filePath)) {
+            return addErrorAndReturn(validationResult, "SecretsFilePath must not be blank.");
+        }
+
+        File secretFile = new File(filePath);
+
+        if (!secretFile.exists()) {
+            return addErrorAndReturn(validationResult, String.format("No secret config file at path '%s'.", filePath));
+        }
+
+        if (secretFile.isDirectory()) {
+            return addErrorAndReturn(validationResult, String.format("Secret config file path '%s' is not a normal file.", filePath));
+        }
+
+        if (!secretFile.canRead()) {
+            return addErrorAndReturn(validationResult, String.format("Unable to read secret config file '%s', check permissions.", filePath));
+        }
+
+        return validationResult;
+    }
+
+    private ValidationResult addErrorAndReturn(ValidationResult validationResult, String message) {
+        validationResult.add(SECRETS_FILE_PATH_PROPERTY, message);
+        return validationResult;
+    }
+}

--- a/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/model/SecretsConfiguration.java
+++ b/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/model/SecretsConfiguration.java
@@ -29,8 +29,8 @@ public class SecretsConfiguration {
     private static final Gson GSON = new GsonBuilder().serializeNulls().create();
 
     @Expose
-    @SerializedName("SecretsFilePath")
-    @Property(name = "SecretsFilePath", required = true)
+    @SerializedName(SECRETS_FILE_PATH_PROPERTY)
+    @Property(name = SECRETS_FILE_PATH_PROPERTY, required = true)
     private String secretsFilePath;
 
     public SecretsConfiguration() {


### PR DESCRIPTION
- File path must not be blank
- Secret config file must be present at given path
- Must be a file
- Plugin must have read permission to a file
