### PR TITLE
Add some unit tests and improve overall performance of reading passwords

### DIFF
--- a/db/src/test/java/cd/go/plugin/secret/filebased/db/CipherTest.java
+++ b/db/src/test/java/cd/go/plugin/secret/filebased/db/CipherTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.plugin.secret.filebased.db;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.security.GeneralSecurityException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class CipherTest {
+
+    @Nested
+    class GenerateKey {
+
+        @Test
+        void shouldGenerate128BitKey() throws NoSuchAlgorithmException {
+            assertThat(Cipher.generateKey())
+                    .hasSize(128 / 8);
+        }
+
+        @Test
+        void shouldGenerateRandomKeyEveryTime() throws NoSuchAlgorithmException {
+            assertThat(Cipher.generateKey())
+                    .isNotEqualTo(Cipher.generateKey());
+        }
+    }
+
+    @Nested
+    class Encrypt {
+
+        @Test
+        void shouldEncrypt() throws GeneralSecurityException {
+            String clearText = "foo";
+
+            String key = Base64.getEncoder().encodeToString(Cipher.generateKey());
+
+            assertThat(Cipher.encrypt(key, clearText))
+                    .doesNotContain(clearText);
+        }
+
+        @Test
+        void shouldEncryptToDifferentValueEveryTime() throws GeneralSecurityException {
+            String clearText = "foo";
+
+            String key = Base64.getEncoder().encodeToString(Cipher.generateKey());
+
+            assertThat(Cipher.encrypt(key, clearText))
+                    .isNotEqualTo(Cipher.encrypt(key, clearText));
+        }
+    }
+
+    @Nested
+    class Decrypt {
+
+        @Test
+        void shouldDecrypt() throws GeneralSecurityException, BadSecretException {
+            String clearText = "foo";
+
+            String key = Base64.getEncoder().encodeToString(Cipher.generateKey());
+
+            String encryptedValue = Cipher.encrypt(key, clearText);
+
+            assertThat(Cipher.decrypt(key, encryptedValue)).isEqualTo(clearText);
+        }
+
+        @Test
+        void shouldFailIfEncryptedValueIsTampered() throws GeneralSecurityException {
+            String key = Base64.getEncoder().encodeToString(Cipher.generateKey());
+
+            assertThatCode(() -> Cipher.decrypt(key, "junk")).hasMessage("Bad cipher text")
+                    .isInstanceOf(BadSecretException.class);
+        }
+    }
+}

--- a/db/src/test/java/cd/go/plugin/secret/filebased/db/SecretsDatabaseTest.java
+++ b/db/src/test/java/cd/go/plugin/secret/filebased/db/SecretsDatabaseTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.plugin.secret.filebased.db;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SecretsDatabaseTest {
+
+    @Test
+    void shouldAddASecret() throws GeneralSecurityException {
+        SecretsDatabase secretsDatabase = new SecretsDatabase();
+        secretsDatabase.addSecret("foo", "bar");
+        assertThat(secretsDatabase.getSecret("foo")).isEqualTo("bar");
+
+    }
+
+    @Test
+    void decryptingASecretShouldCacheIt() throws GeneralSecurityException {
+        SecretsDatabase secretsDatabase = new SecretsDatabase();
+
+        secretsDatabase.addSecret("foo", "bar");
+        assertThat(secretsDatabase.decryptedSecrets).doesNotContainKeys("foo");
+
+        secretsDatabase.getSecret("foo");
+        assertThat(secretsDatabase.decryptedSecrets).containsKeys("foo");
+    }
+
+    @Test
+    void removingASecretShouldRemoveItFromCache() throws GeneralSecurityException {
+        SecretsDatabase secretsDatabase = new SecretsDatabase();
+
+        secretsDatabase.addSecret("foo", "bar");
+
+        // populate cache
+        secretsDatabase.getSecret("foo");
+        assertThat(secretsDatabase.decryptedSecrets).containsKeys("foo");
+
+        // remove secret
+        secretsDatabase.removeSecret("foo");
+        assertThat(secretsDatabase.decryptedSecrets).doesNotContainKeys("foo");
+    }
+
+    @Test
+    void addingASecretShouldRemoveItFromCache() throws GeneralSecurityException {
+        SecretsDatabase secretsDatabase = new SecretsDatabase();
+
+        secretsDatabase.addSecret("foo", "bar");
+
+        // populate cache
+        secretsDatabase.getSecret("foo");
+        assertThat(secretsDatabase.decryptedSecrets).containsKeys("foo");
+
+        // add secret
+        secretsDatabase.addSecret("foo", "bar");
+        assertThat(secretsDatabase.decryptedSecrets).doesNotContainKeys("foo");
+    }
+
+    @Nested
+    class Persistance {
+
+        @Test
+        void shouldPersistDBToDisk(@TempDir File tempDir) throws GeneralSecurityException, IOException {
+            SecretsDatabase secretsDatabase = new SecretsDatabase();
+
+            secretsDatabase.addSecret("foo", "bar");
+
+            secretsDatabase.saveTo(new File(tempDir, "db.json"));
+
+            SecretsDatabase loadedDB = SecretsDatabase.readFrom(new File(tempDir, "db.json"));
+
+            // is able to decrypt
+            assertThat(loadedDB.getSecret("foo")).isEqualTo("bar");
+
+            // and saves the passphrase and all secrets
+            assertThat(secretsDatabase.getSecretKey()).isEqualTo(loadedDB.getSecretKey());
+            assertThat(secretsDatabase.getSecrets()).isEqualTo(loadedDB.getSecrets());
+        }
+    }
+}

--- a/gocd-file-based-secrets-plugin/build.gradle
+++ b/gocd-file-based-secrets-plugin/build.gradle
@@ -14,16 +14,24 @@
  * limitations under the License.
  */
 
+plugins {
+    id "me.champeau.gradle.jmh" version "0.4.8"
+}
+
 configurations {
     extractedAtTopLevel
 }
 
 dependencies {
-    compile group: 'cd.go.plugin.base', name: 'gocd-plugin-base', version: '0.0.1'
     compileOnly group: 'cd.go.plugin', name: 'go-plugin-api', version: '18.9.0'
+    compile group: 'cd.go.plugin.base', name: 'gocd-plugin-base', version: '0.0.1'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
+
     compile project(':db')
     compile project(':cli')
+
+    compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.8'
+    annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.8'
 
     extractedAtTopLevel project(':jar-class-loader')
 
@@ -54,4 +62,8 @@ jar {
     from(project.configurations.extractedAtTopLevel.collect { it.isDirectory() ? it : zipTree(it) }) {
         into("/")
     }
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/gocd-file-based-secrets-plugin/src/jmh/java/cd/go/plugin/secret/filebased/executors/SecretsDatabasePerformanceBenchmark.java
+++ b/gocd-file-based-secrets-plugin/src/jmh/java/cd/go/plugin/secret/filebased/executors/SecretsDatabasePerformanceBenchmark.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.plugin.secret.filebased.executors;
+
+import cd.go.plugin.secret.filebased.db.SecretsDatabase;
+import cd.go.plugin.secret.filebased.util.LRUCache;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Collections.synchronizedMap;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1, jvmArgs = {"-Xms512m", "-Xmx512m"})
+@Warmup(iterations = 2, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+public class SecretsDatabasePerformanceBenchmark {
+
+    private final Map<File, CacheEntry> fileStatCache = synchronizedMap(new LRUCache<>(3));
+
+    private SecretsDatabase secretsDatabase;
+
+    private File tempFile;
+
+    @Setup
+    public void setup() throws GeneralSecurityException, IOException {
+        tempFile = new File("tmp.secrets.db");
+        tempFile.deleteOnExit();
+
+        secretsDatabase = new SecretsDatabase();
+        secretsDatabase.addSecret("foo", "bar");
+
+        secretsDatabase.saveTo(tempFile);
+    }
+
+    @Benchmark
+    public void readDatabaseEachTime(Blackhole bh) throws NoSuchAlgorithmException, IOException {
+        SecretsDatabase secretsDatabase = SecretsDatabase.readFrom(tempFile);
+        bh.consume(secretsDatabase.getSecret("foo"));
+    }
+
+    @Benchmark
+    public void readDatabaseFromCache(Blackhole bh) {
+        bh.consume(secretsDatabase.getSecret("foo"));
+    }
+
+    @Benchmark
+    public void readDatabaseThroughFileStatCache(Blackhole bh) throws IOException {
+        bh.consume(fileStatCache
+                .compute(tempFile, LookupSecretsRequestExecutor.FileCacheEntryCacheEntryBiFunction.INSTANCE)
+                .getSecretsDatabase()
+                .getSecret("foo"));
+    }
+}

--- a/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/executors/CacheEntry.java
+++ b/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/executors/CacheEntry.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.plugin.secret.filebased.executors;
+
+import cd.go.plugin.secret.filebased.db.SecretsDatabase;
+import cd.go.plugin.secret.filebased.util.FileStat;
+
+import java.io.File;
+import java.io.IOException;
+
+class CacheEntry {
+
+    private final FileStat fileStat;
+
+    private volatile SecretsDatabase secretsDatabase;
+
+    CacheEntry(File file) {
+        this.fileStat = new FileStat(file);
+    }
+
+    void refresh() throws IOException {
+        if (this.fileStat.changed(5000)) {
+            this.secretsDatabase = null;
+        }
+    }
+
+    // double checked locks
+    public SecretsDatabase getSecretsDatabase() throws IOException {
+        SecretsDatabase localRef = secretsDatabase;
+        if (localRef == null) {
+            synchronized (this) {
+                localRef = secretsDatabase;
+                if (localRef == null) {
+                    secretsDatabase = localRef = SecretsDatabase.readFrom(this.fileStat.getFile());
+                }
+            }
+        }
+        return localRef;
+    }
+
+}

--- a/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/util/FileStat.java
+++ b/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/util/FileStat.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.plugin.secret.filebased.util;
+
+import lombok.Getter;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.commons.lang3.ArrayUtils;
+
+import java.io.*;
+import java.security.DigestOutputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class FileStat {
+
+    private final File file;
+
+    private long lastStatTime;
+
+    private boolean exists;
+
+    private long lastModified;
+
+    private boolean directory;
+
+    private long length;
+
+    private List<Byte> digest;
+
+    @Getter(lazy = true)
+    // lazy initialize, because performance
+    private final MessageDigest messageDigest = createDigester();
+
+    public FileStat(File file) {
+        this.file = file;
+    }
+
+    public boolean changed(int withinInterval) {
+        if (System.currentTimeMillis() <= lastStatTime + withinInterval) {
+            return false;
+        }
+        lastStatTime = System.currentTimeMillis();
+        // cache original values
+        final boolean origExists = exists;
+        final long origLastModified = lastModified;
+        final boolean origDirectory = directory;
+        final long origLength = length;
+        final List<Byte> origDigest = digest;
+
+        // refresh the values
+        refresh();
+
+        // check if any values have changed
+        return exists != origExists ||
+                lastModified != origLastModified ||
+                directory != origDirectory ||
+                length != origLength ||
+                !digest.equals(origDigest);
+    }
+
+    void refresh() {
+        exists = file.exists();
+        directory = exists && file.isDirectory();
+        lastModified = exists ? file.lastModified() : 0;
+        length = (exists && !directory) ? file.length() : 0;
+        digest = (exists && !directory) ? computeDigest() : Collections.emptyList();
+    }
+
+    private List<Byte> computeDigest() {
+        MessageDigest messageDigest = getMessageDigest();
+        messageDigest.reset();
+        try (InputStream is = new BufferedInputStream(new FileInputStream(file), 1024 * 32)) {
+            IOUtils.copy(is, new DigestOutputStream(new NullOutputStream(), messageDigest));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        return Arrays.asList(ArrayUtils.toObject(messageDigest.digest()));
+    }
+
+    private static MessageDigest createDigester() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException();
+        }
+    }
+
+    public File getFile() {
+        return file;
+    }
+}

--- a/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/util/LRUCache.java
+++ b/gocd-file-based-secrets-plugin/src/main/java/cd/go/plugin/secret/filebased/util/LRUCache.java
@@ -14,15 +14,21 @@
  * limitations under the License.
  */
 
-dependencies {
-    compile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
-    compile group: 'commons-io', name: 'commons-io', version: '2.6'
+package cd.go.plugin.secret.filebased.util;
 
-    testCompile group: 'org.assertj', name: 'assertj-core', version: '3.12.2'
-    testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.4.2'
-    testRuntime group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.4.2'
-}
+import java.util.LinkedHashMap;
+import java.util.Map;
 
-test {
-    useJUnitPlatform()
+public class LRUCache<K, V> extends LinkedHashMap<K, V> {
+
+    private int cacheSize;
+
+    public LRUCache(int cacheSize) {
+        super(16, 0.75f, true);
+        this.cacheSize = cacheSize;
+    }
+
+    protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+        return size() >= cacheSize;
+    }
 }

--- a/gocd-file-based-secrets-plugin/src/test/java/cd/go/plugin/secret/filebased/util/FileStatTest.java
+++ b/gocd-file-based-secrets-plugin/src/test/java/cd/go/plugin/secret/filebased/util/FileStatTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.plugin.secret.filebased.util;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FileStatTest {
+
+    @Nested
+    class Changed_method {
+
+        @Test
+        void shouldStatANonExistantFile(@TempDir File tempDir) {
+            File file = new File(tempDir, UUID.randomUUID().toString());
+
+            FileStat fileStat = new FileStat(file);
+            assertThat(fileStat.changed(0)).isTrue();
+            assertThat(fileStat.changed(0)).isFalse();
+        }
+
+        @Test
+        void shouldReturnTrueIfFileHasBeenModifiedWithinAnInterval(@TempDir File tempDir) throws InterruptedException, IOException {
+            File file = new File(tempDir, UUID.randomUUID().toString());
+            assertThat(file.createNewFile()).isTrue();
+
+            FileStat fileStat = new FileStat(file);
+            fileStat.refresh();
+
+            assertThat(fileStat.changed(0)).isFalse();
+            Thread.sleep(1500);
+
+            assertThat(file.setLastModified(System.currentTimeMillis())).isTrue();
+
+            assertThat(fileStat.changed(2000)).isFalse();
+
+            assertThat(fileStat.changed(1000)).isTrue();
+        }
+
+        @Test
+        void shouldReturnTrueIfFileContentsChanged(@TempDir File tempDir) throws IOException, InterruptedException {
+            File file = new File(tempDir, UUID.randomUUID().toString());
+            assertThat(file.createNewFile()).isTrue();
+
+            FileStat fileStat = new FileStat(file);
+            fileStat.refresh();
+
+            assertThat(fileStat.changed(0)).isFalse();
+            FileUtils.writeStringToFile(file, "foo", UTF_8);
+            Thread.sleep(100);
+            assertThat(fileStat.changed(110)).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
- Lazily remember the decrypted secrets in a map as more secrets are decrypted
- Perform a `stat()` like operation to check if the file was modified in the last 5 seconds
  before reloading the DB file from disk.

A local run on a 2018 MBP, 2.2GHz i7 Processor, 2400 MHz DDR4
gives the following output using JMH:

```
Benchmark                                                         Mode  Cnt      Score       Error   Units
SecretsDatabasePerformanceTest.readDatabaseEachTime              thrpt    3     27.225 ±     4.962  ops/ms
SecretsDatabasePerformanceTest.readDatabaseFromCache             thrpt    3  95100.216 ± 12670.944  ops/ms
SecretsDatabasePerformanceTest.readDatabaseThroughFileStatCache  thrpt    3  18884.347 ±  1546.321  ops/ms
```