### PR TITLE
Describe expected format of JSON document

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ The configuration can be added directly to the `config.xml` using the `<secretCo
       </secretConfig>
     </secretConfigs>
     ```
+A secret file is made of JSON, and has the following data structure:
+
+```json
+[
+  { "key": "foo", "value": "bar" }
+]
+```
 
 ## Troubleshooting
 


### PR DESCRIPTION
When the JSON secrets file is read, it is expecting the JSON to be in a certain format. I've added this info into the docs for others to see, without having to read through code :smile: