### PR TITLE
Fix description for `name` parameter in cli help

### DIFF
--- a/cli/src/main/java/cd/go/plugin/secret/filebased/cli/args/HasNameArgs.java
+++ b/cli/src/main/java/cd/go/plugin/secret/filebased/cli/args/HasNameArgs.java
@@ -19,6 +19,6 @@ package cd.go.plugin.secret.filebased.cli.args;
 import com.beust.jcommander.Parameter;
 
 public abstract class HasNameArgs extends DatabaseFileArgs {
-    @Parameter(names = {"--name", "-n"}, required = true, description = "The name of the secret to remove.")
+    @Parameter(names = {"--name", "-n"}, required = true, description = "The name of the secret.")
     public String key;
 }


### PR DESCRIPTION
The help content for the CLI always shows "The name of the secret to remove" for all commands -- not just the `remove` command. This just fixes that typo.

Before:
```
Usage: java -jar <path.to.plugin.jar.file> [options] [command] [command options]
  Options:
    --help, -h
      Prints this help.
  Commands:
    ...
    add      Adds a secret.
      Usage: add [options]
        Options:
        * --file, -f
            The path to the secret database file.
        * --name, -n
            The name of the secret to remove.
        * --value, -v
            The value of the secret.
```

After:
```
Usage: java -jar <path.to.plugin.jar.file> [options] [command] [command options]
  Options:
    --help, -h
      Prints this help.
  Commands:
    ...
    add      Adds a secret.
      Usage: add [options]
        Options:
        * --file, -f
            The path to the secret database file.
        * --name, -n
            The name of the secret.
        * --value, -v
            The value of the secret.
```